### PR TITLE
Add AUTH_LDAP_ALWAY_UPDATE_USER to ldap config

### DIFF
--- a/configuration/ldap/ldap_config.py
+++ b/configuration/ldap/ldap_config.py
@@ -109,3 +109,6 @@ AUTH_LDAP_USER_ATTR_MAP = {
     "last_name": environ.get('AUTH_LDAP_ATTR_LASTNAME', 'sn'),
     "email": environ.get('AUTH_LDAP_ATTR_MAIL', 'mail')
 }
+
+# Update user object with the latest values from the LDAP directory every time the user logs in.
+AUTH_LDAP_ALWAYS_UPDATE_USER = environ.get('AUTH_LDAP_ALWAYS_UPDATE_USER', 'True').lower() == 'true'


### PR DESCRIPTION
This change exposes the Django setting AUTH_LDAP_ALWAYS_UPDATE_USER as environment variable to simplify deployments with readonly databases and LDAP based authentication as no extra file is required to be mounted into the container anymore.

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: #1364

## New Behavior


The Django Auth LDAP parameter AUTH_LDAP_ALWAYS_UPDATE_USER is exposed as environment variable.

## Contrast to Current Behavior

To change the parameter from its default value (e.g. in readonly DB environments) it is required to  create en extra file (extra.py) and mount it into the container.


## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

There are scenarios where NetBox might be deployed in Maintenance Mode connected to a readonly database in combination with LDAP based authentication. In this scenario, an additional Python configuration file has to be created to set the parameter AUTH_LDAP_ALWAYS_UPDATE_USER to `False` in order to prevent Django from updating the `last_login` field of the user.
This file as to be deployed and mounted into the container which unnecessarily increases deployment complexity.
With this change, the parameter can be specified via container environment variable along all other LDAP related settings,


## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

## Proposed Release Note Entry


Expose AUTH_LDAP_ALWAYS_UPDATE_USER via environment variable


## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
